### PR TITLE
Fix hardcoding of portal.cs.ubc.ca

### DIFF
--- a/app/ts/App.ts
+++ b/app/ts/App.ts
@@ -47,8 +47,8 @@ export class App {
             this.backendURL = this.backendSTAG;
             this.frontendURL = this.frontendSTAG;
         } else {
-            this.backendURL = this.backendPROD;
-            this.frontendURL = this.frontendPROD;
+            this.backendURL = "https://" + window.location.hostname + ":5000/"
+            this.frontendURL = "https://" + window.location.hostname + "/"
         }
 
         this.authHelper = new AuthHelper(this.backendURL);


### PR DESCRIPTION
Use window.location.hostname to build URLs.

Was there a reason for the hardcoding here?
This patch makes authentication work on the new servers (i.e. cs210.ugrad.cs.ubc.ca)